### PR TITLE
fix(deploy): make external appliance hostname configurable

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 # Host ports exposed by Unicron
+# DNS hostname used by browsers; no scheme, port, or path.
+UNICRON_CENTRAL_FQDN=localhost
 UNICRON_APP_PORT=8444
 UNICRON_AGENT_MTLS_PORT=9443
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@
 
 # LogForge Unicron
 
+### Access from another device
+
+Before first startup, set `UNICRON_CENTRAL_FQDN` in `.env` to the server's
+reachable DNS hostname (for example `logs.example.com`). Configure your DNS
+to resolve that name to the Docker server, then open
+`https://logs.example.com:8444/unicron/` (use your configured app port).
+Compose also maps this name to loopback inside the appliance for internal CA
+communication; this does not restrict the published host ports.
+
+The appliance issues its own certificate. Trust its root CA on client devices
+to validate HTTPS. Merely adding a name to `TRAEFIK_ROUTER_HOSTS` does not
+update the certificate. Existing installations require an appliance release
+supporting hostname-change certificate reissuance before changing this setting.
+Do not delete the data volume or certificate authority to change the hostname.
+
 Self-hosted Docker monitoring and control in one Docker Compose deployment.
 Unicron is a Docker-native dashboard for local and agent-forwarded logs,
 metrics, Docker events, alert rules, notifications, file access, and safe

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     security_opt:
       - no-new-privileges:true
     extra_hosts:
+      - ${UNICRON_CENTRAL_FQDN:-localhost}:127.0.0.1
       - unicron-stepca:127.0.0.1
       - unicron-stepca-ra:127.0.0.1
       - unicron.central:127.0.0.1
@@ -32,7 +33,7 @@ services:
     environment:
       TMPDIR: /run/pyinstaller
       UNICRON_APPLIANCE_CONTAINER_NAME: unicron-appliance
-      UNICRON_CENTRAL_FQDN: localhost
+      UNICRON_CENTRAL_FQDN: ${UNICRON_CENTRAL_FQDN:-localhost}
       UNICRON_CENTRAL_PORT: "443"
       UNICRON_PUBLIC_CENTRAL_PORT: ${UNICRON_APP_PORT:-8444}
       UNICRON_CENTRAL_MTLS_PORT: "8443"


### PR DESCRIPTION
Expose UNICRON_CENTRAL_FQDN through .env, map it internally for appliance connectivity, and document external DNS access and certificate trust. Tested with the matching appliance change inside a Proxmox-managed Debian VM, including verified HTTPS and authenticated dashboard access from outside the VM. The matching appliance is published as latest and 3.0.0. Related to issue #33; this does not claim validation of the reporter's exact host or remote-agent setup.